### PR TITLE
Grab CPU stats from iostat on a mac

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -7,8 +7,8 @@ source "$CURRENT_DIR/helpers.sh"
 print_cpu_percentage() {
 	if [ -e "/proc/stat" ]; then
 		grep 'cpu ' /proc/stat | awk '{usage=($2+$4)*100/($2+$4+$5)} END {printf("%.1f%", usage)}'
-  elif [ is_osx ]; then
-    iostat -w 1 -c 2 | tail -1 | awk '{usage=100-$6} END {printf("%d%%",usage)}';
+	elif [ is_osx ]; then
+		iostat -w 1 -c 2 | tail -1 | awk '{usage=100-$6} END {printf("%d%%",usage)}';
 	fi
 }
 


### PR DESCRIPTION
OSX doesn't have procfs, so grabbing cpu usage from /proc/stat won't
work.

Rather, if is_osx() returns true, get stats from the output of the
iostat utility.

Note that the first line of data that iostat prints is always averaged
over system uptime. You need to tell it to print two lines, averaging
over one second, and use the data in the second line.
