### PR TITLE
Force number of devices to 1 so as not to break the awk script.

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -8,7 +8,7 @@ print_cpu_percentage() {
 	if [ -e "/proc/stat" ]; then
 		grep 'cpu ' /proc/stat | awk '{usage=($2+$4)*100/($2+$4+$5)} END {printf("%.1f%", usage)}'
 	elif [ is_osx ]; then
-		iostat -w 1 -c 2 | tail -1 | awk '{usage=100-$6} END {printf("%d%%",usage)}';
+		iostat -w 1 -c 2 -n 1 | tail -1 | awk '{usage=100-$6} END {printf("%d%%",usage)}';
 	fi
 }
 


### PR DESCRIPTION
Sorry, I missed a not-so-edge case! 

The awk snippet that grabs the cpu stats assumes that iostat's only reporting on one disk, like this: 

```
          disk0       cpu     load average
    KB/t tps  MB/s  us sy id   1m   5m   15m
   33.00   8  0.26   6  7 87  1.46 1.49 1.57
    8.96  38  0.33   2  5 92  1.46 1.49 1.57
```

...and that idle cpu % will be in column 6.

 If there's more than one disk, though, the cpu stats will wind up in the "wrong" column...

```
          disk0           disk2       cpu     load average
    KB/t tps  MB/s     KB/t tps  MB/s  us sy id   1m   5m   15m
   32.99   8  0.26   151.00   0  0.00   6  7 87  1.48 1.50 1.57
    0.00   0  0.00     0.00   0  0.00   3  5 92  1.48 1.50 1.57
```

This change calls iostat with -n 1, which forces it to report on only one disk.
