### PR TITLE
doesn't print cpu usage on MacOSX.

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 print_cpu_percentage() {
-	if [ is_cygwin ]; then
+	if is_cygwin; then
 		usage="$(WMIC cpu get LoadPercentage | grep -Eo '^[0-9]+')"
 		printf "%5.1f%%" $usage
 	elif [ -e "/proc/stat" ]; then


### PR DESCRIPTION
cpu_percentage.sh doesn't print cpu usage on my MacOSX.  It always tries to use WMIC.
```
$ uname -a
Darwin Yuichi-no-MacBook-Pro.local 14.1.0 Darwin Kernel Version 14.1.0: Mon Dec 22 23:10:38 PST 2014; root:xnu-2782.10.72~2/RELEASE_X86_64 x86_64 i386 MacBookPro10,1 Darwin
$ ./cpu_percentage.sh
./cpu_percentage.sh: line 9: WMIC: command not found
  0.0%
```

I have confirmed fixed version prints cpu usage on cygwin and MacOSX.