### PR TITLE
use correct value if running on FreeBSD

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -10,8 +10,10 @@ print_cpu_percentage() {
 		printf "%5.1f%%" $usage
 	elif [ -e "/proc/stat" ]; then
 		grep 'cpu ' /proc/stat | awk '{usage=($2+$4)*100/($2+$4+$5)} END {printf("%5.1f%", usage)}'
-	elif [ is_osx ]; then
+	elif is_osx; then
 		iostat -w 1 -c 2 -n 1 | tail -1 | awk '{usage=100-$6} END {printf("%d%%",usage)}';
+	elif is_freebsd; then
+		iostat -w 1 -c 2 -n 1 | tail -1 | awk '{usage=100-$10} END {printf("%d%%",usage)}';
 	fi
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,6 +13,10 @@ is_osx() {
 	[ $(uname) == "Darwin" ]
 }
 
+is_freebsd() {
+	[ $(uname) == "FreeBSD" ]
+}
+
 is_cygwin() {
 	command -v WMIC > /dev/null
 }


### PR DESCRIPTION
One can now have that feature working even on FreeBSD machines.
Tested on OSX 10.11.2 and FreeBSD 10.2.