### PR TITLE
iostat current CPU usage

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -8,7 +8,7 @@ print_cpu_percentage() {
 	if command_exists "iostat"; then
 
 		if is_linux_iostat; then
-			iostat -c | tr -s ' ' ';' | grep -e '^;' |  cut -d ';' -f 2 | awk '{print $1"%"}'
+			iostat -cy 1 1 | tr -s ' ' ';' | grep -e '^;' |  cut -d ';' -f 2 | awk '{print $1"%"}'
 		elif is_osx; then
 			iostat | tail -1 | tr -s ' ' ';' | sed -e 's/^;//' | cut -d ';' -f 9 | awk '{print $1"%"}'
 		elif is_freebsd; then


### PR DESCRIPTION
https://serverfault.com/questions/324167/iostat-see-current-usage-rather-than-average

I'd prefer the tmux plugin to show a live version of CPU usage (default is average since boot up).

Unfortunately iostat only seems to support this by telling it to take an average of the last second, which makes this change not ideal.