### PR TITLE
Replace , with . in cpu-load for German systems

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -8,16 +8,16 @@ print_cpu_percentage() {
 	if command_exists "iostat"; then
 
 		if is_linux_iostat; then
-			iostat -c 1 2 | tail -n 2 | head -n 1 | awk '{usage=100-$NF} END {printf("%5.1f%%", usage)}'
+			iostat -c 1 2 | tail -n 2 | head -n 1 | awk '{usage=100-$NF} END {printf("%5.1f%%", usage)}' | sed 's/,/./'
 		elif is_osx; then
-			iostat -c 2 disk0 | tail -n 1 | awk '{usage=100-$6} END {printf("%5.1f%%", usage)}'
+			iostat -c 2 disk0 | tail -n 1 | awk '{usage=100-$6} END {printf("%5.1f%%", usage)}' | sed 's/,/./'
 		elif is_freebsd || is_openbsd; then
-			iostat -c 2 | tail -n 1 | awk '{usage=100-$NF} END {printf("%5.1f%%", usage)}'
+			iostat -c 2 | tail -n 1 | awk '{usage=100-$NF} END {printf("%5.1f%%", usage)}' | sed 's/,/./'
 		else
 			echo "Unknown iostat version please create an issue"
 		fi
 	elif command_exists "sar"; then
-		sar -u 1 1 | tail -n 1 | awk '{usage=100-$NF} END {printf("%5.1f%%", usage)}'
+		sar -u 1 1 | tail -n 1 | awk '{usage=100-$NF} END {printf("%5.1f%%", usage)}' | sed 's/,/./'
 	else
 		if is_cygwin; then
 			usage="$(WMIC cpu get LoadPercentage | grep -Eo '^[0-9]+')"


### PR DESCRIPTION
I'm using the Plugin on macOS and receiving a wrong `cpu_load_status` int the `print_bg_color`-helper function.

My systems language is German, so that reading the `print_cpu_percentage`-helper function gives me a float seperated with `,` instead of `.`. As a consequence the following comparison gives me wrong results.