### PR TITLE
Use current cpu percentage

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -23,7 +23,7 @@ print_cpu_percentage() {
 			usage="$(WMIC cpu get LoadPercentage | grep -Eo '^[0-9]+')"
 			printf "%5.1f%%" $usage
 		else
-			load=`ps -aux | awk '{print $3}' | tail -n+2 | awk '{s+=$1} END {print s}'`
+			load=`top -bn 1 | awk 'NR>7{s+=$9} END {print s}'`
 			cpus=$(cpus_number)
 			echo "$load $cpus" | awk '{printf "%5.2f%%", $1/$2}'
 		fi


### PR DESCRIPTION
Close #19 

A more accurate cpu percentage computation in case that `iostat` and `sar` are not available.