### PR TITLE
update color names

### DIFF
--- a/scripts/cpu_bg_color.sh
+++ b/scripts/cpu_bg_color.sh
@@ -8,9 +8,9 @@ cpu_low_bg_color=""
 cpu_medium_bg_color=""
 cpu_high_bg_color=""
 
-cpu_low_default_bg_color="#[bg=green]"
-cpu_medium_default_bg_color="#[bg=yellow]"
-cpu_high_default_bg_color="#[bg=red]"
+cpu_low_default_bg_color="#[bg=colour10]"
+cpu_medium_default_bg_color="#[bg=colour3]"
+cpu_high_default_bg_color="#[bg=colour1]"
 
 get_bg_color_settings() {
   cpu_low_bg_color=$(get_tmux_option "@cpu_low_bg_color" "$cpu_low_default_bg_color")

--- a/scripts/cpu_fg_color.sh
+++ b/scripts/cpu_fg_color.sh
@@ -8,9 +8,9 @@ cpu_low_fg_color=""
 cpu_medium_fg_color=""
 cpu_high_fg_color=""
 
-cpu_low_default_fg_color="#[fg=green]"
-cpu_medium_default_fg_color="#[fg=yellow]"
-cpu_high_default_fg_color="#[fg=red]"
+cpu_low_default_fg_color="#[fg=colour10]"
+cpu_medium_default_fg_color="#[fg=colour3]"
+cpu_high_default_fg_color="#[fg=colour1]"
 
 get_fg_color_settings() {
   cpu_low_fg_color=$(get_tmux_option "@cpu_low_fg_color" "$cpu_low_default_fg_color")

--- a/scripts/gpu_bg_color.sh
+++ b/scripts/gpu_bg_color.sh
@@ -8,9 +8,9 @@ gpu_low_bg_color=""
 gpu_medium_bg_color=""
 gpu_high_bg_color=""
 
-gpu_low_default_bg_color="#[bg=green]"
-gpu_medium_default_bg_color="#[bg=yellow]"
-gpu_high_default_bg_color="#[bg=red]"
+gpu_low_default_bg_color="#[bg=colour10]"
+gpu_medium_default_bg_color="#[bg=colour3]"
+gpu_high_default_bg_color="#[bg=colour1]"
 
 get_bg_color_settings() {
   gpu_low_bg_color=$(get_tmux_option "@gpu_low_bg_color" "$gpu_low_default_bg_color")

--- a/scripts/gpu_fg_color.sh
+++ b/scripts/gpu_fg_color.sh
@@ -8,9 +8,9 @@ gpu_low_fg_color=""
 gpu_medium_fg_color=""
 gpu_high_fg_color=""
 
-gpu_low_default_fg_color="#[fg=green]"
-gpu_medium_default_fg_color="#[fg=yellow]"
-gpu_high_default_fg_color="#[fg=red]"
+gpu_low_default_fg_color="#[fg=colour10]"
+gpu_medium_default_fg_color="#[fg=colour3]"
+gpu_high_default_fg_color="#[fg=colour1]"
 
 get_fg_color_settings() {
   gpu_low_fg_color=$(get_tmux_option "@gpu_low_fg_color" "$gpu_low_default_fg_color")


### PR DESCRIPTION
It seems that colourXXX names can be recognized by more terminals than names like "red" "yellow".