### PR TITLE
use mpstat first

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -9,8 +9,9 @@ cpu_percentage_format="%3.1f%%"
 print_cpu_percentage() {
   cpu_percentage_format=$(get_tmux_option "@cpu_percentage_format" "$cpu_percentage_format")
 
-  if command_exists "iostat"; then
-
+  if command_exists "mpstat"; then
+	  mpstat 1 1 | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}'
+  elif command_exists "iostat"; then
     if is_linux_iostat; then
       iostat -c 1 2 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
     elif is_osx; then


### PR DESCRIPTION
`mpstat` is better than `iostat` on checking CPU usages.
`mpstat` works with WSL on Win10 but `iostat` doesn't.
`mpstat` makes no calls to disk APIs but `iostat` does.