### PR TITLE
Fixed issue where `free` command fails to be parsed.

### DIFF
--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -16,7 +16,7 @@ print_ram_percentage() {
   ram_percentage_format=$(get_tmux_option "@ram_percentage_format" "$ram_percentage_format")
 
   if command_exists "free"; then
-    free | awk -v format="$ram_percentage_format" '$1 ~ /Mem/ {printf(format, 100*$3/$2)}'
+    LC_ALL=C free | awk -v format="$ram_percentage_format" '$1 ~ /Mem/ {printf(format, 100*$3/$2)}'
   elif command_exists "vm_stat"; then
     # page size of 4096 bytes
     stats="$(vm_stat)"


### PR DESCRIPTION
Very minor bug.

If your system's language is not English, free will fail to parse.

Setting `LC_ALL=C` fixes this.