### PR TITLE
fix calculation of ram percentage with vm_stat

### DIFF
--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -8,7 +8,7 @@ source "$CURRENT_DIR/helpers.sh"
 ram_percentage_format="%3.1f%%"
 
 sum_macos_vm_stats() {
-  grep -o '[0-9]*' \
+  grep -Eo '[0-9]+' \
   | awk '{ a += $1 * 4096 } END { print a }' 
 }
 


### PR DESCRIPTION
The statement "grep -o '[0-9]*'" did not find the numbers of vm_stat. I changed it to "grep -Eo '[0-9]+'". It seems to work. 