### PR TITLE
Fix fcomp to modify `load_status` behavior

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -34,9 +34,9 @@ is_linux_iostat() {
   iostat -c &> /dev/null
 }
 
-# is second float bigger?
+# is second float bigger or equal?
 fcomp() {
-  awk -v n1=$1 -v n2=$2 'BEGIN {if (n1<n2) exit 0; exit 1}'
+  awk -v n1=$1 -v n2=$2 'BEGIN {if (n1<=n2) exit 0; exit 1}'
 }
 
 load_status() {


### PR DESCRIPTION
Currently, `load_status` behaves as below:

- 80 < `$percentage`: high
- 30 < `$percentage` < 80: medium
- else: low
  - **'else' includes `$percentage` == 80**.

This PR modifies this behavior to as below:

- 80 <= `$percentage`: high
- 30 <= `$percentage` < 80: medium
- else: low
