### PR TITLE
Localization issue :: LC_ALL overwrites LANG

### DIFF
--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -2,6 +2,7 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export LANG=C
+export LC_ALL=C
 
 source "$CURRENT_DIR/helpers.sh"
 


### PR DESCRIPTION
From the old PR here:
https://github.com/tmux-plugins/tmux-cpu/pull/47

we still have issues with localization, mainly that `LC_ALL` is a commonly exported env variable, and it overwrites `LANG`.

turns out if you have both variables set (very common), this PR https://github.com/tmux-plugins/tmux-cpu/pull/46 still does not fix the issue

I have attached a photo below that shows the difference

![图片](https://user-images.githubusercontent.com/50598611/80270064-e337e280-8669-11ea-9298-fa664e16bdc8.png)
