### PR TITLE
add cached eval

### DIFF
--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -12,22 +12,22 @@ print_cpu_percentage() {
   if command_exists "iostat"; then
 
     if is_linux_iostat; then
-      iostat -c 1 2 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
+      cached_eval iostat -c 1 2 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
     elif is_osx; then
-      iostat -c 2 disk0 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$6} END {printf(format, usage)}' | sed 's/,/./'
+      cached_eval iostat -c 2 disk0 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$6} END {printf(format, usage)}' | sed 's/,/./'
     elif is_freebsd || is_openbsd; then
-      iostat -c 2 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
+      cached_eval iostat -c 2 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
     else
       echo "Unknown iostat version please create an issue"
     fi
   elif command_exists "sar"; then
-    sar -u 1 1 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
+    cached_eval sar -u 1 1 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
   else
     if is_cygwin; then
-      usage="$(WMIC cpu get LoadPercentage | grep -Eo '^[0-9]+')"
+      usage="$(cached_eval WMIC cpu get LoadPercentage | grep -Eo '^[0-9]+')"
       printf "$cpu_percentage_format" "$usage"
     else
-      load=`ps -aux | awk '{print $3}' | tail -n+2 | awk '{s+=$1} END {print s}'`
+      load=`cached_eval ps -aux | awk '{print $3}' | tail -n+2 | awk '{s+=$1} END {print s}'`
       cpus=$(cpus_number)
       echo "$load $cpus" | awk -v format="$cpu_percentage_format" '{printf format, $1/$2}'
     fi

--- a/scripts/gpu_percentage.sh
+++ b/scripts/gpu_percentage.sh
@@ -10,9 +10,9 @@ print_gpu_percentage() {
   gpu_percentage_format=$(get_tmux_option "@gpu_percentage_format" "$gpu_percentage_format")
 
   if command_exists "nvidia-smi"; then
-    loads=$(nvidia-smi)
+    loads=$(cached_eval nvidia-smi)
   elif command_exists "cuda-smi"; then
-    loads=$(cuda-smi)
+    loads=$(cached_eval cuda-smi)
   else
     echo "No GPU"
     return

--- a/scripts/gram_percentage.sh
+++ b/scripts/gram_percentage.sh
@@ -10,9 +10,9 @@ print_gram_percentage() {
   gram_percentage_format=$(get_tmux_option "@gram_percentage_format" "$gram_percentage_format")
 
   if command_exists "nvidia-smi"; then
-    loads=$(nvidia-smi | sed -nr 's/.*\s([0-9]+)MiB\s*\/\s*([0-9]+)MiB.*/\1 \2/p')
+    loads=$(cached_eval nvidia-smi | sed -nr 's/.*\s([0-9]+)MiB\s*\/\s*([0-9]+)MiB.*/\1 \2/p')
   elif command_exists "cuda-smi"; then
-    loads=$(cuda-smi | sed -nr 's/.*\s([0-9.]+) of ([0-9.]+) MB.*/\1 \2/p' | awk '{print $2-$1" "$2}')
+    loads=$(cached_eval cuda-smi | sed -nr 's/.*\s([0-9.]+) of ([0-9.]+) MB.*/\1 \2/p' | awk '{print $2-$1" "$2}')
   else
     echo "No GPU"
     return

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -70,7 +70,7 @@ get_tmp_dir() {
 }
 
 get_time() {
-  date +%s
+  date +%s.%N
 }
 
 get_cache_val(){

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -64,7 +64,9 @@ command_exists() {
 }
 
 get_tmp_dir() {
-  echo "${TMPDIR:-/tmp}/tmux-$EUID-cpu"
+  local tmpdir="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+  [ -d "$tmpdir" ] || local tmpdir=~/tmp
+  echo "$tmpdir/tmux-$EUID-cpu"
 }
 
 get_time() {

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -62,3 +62,44 @@ command_exists() {
   local command="$1"
   command -v "$command" &> /dev/null
 }
+
+get_tmp_dir() {
+  echo "${TMPDIR:-/tmp}/tmux-$EUID-cpu"
+}
+
+get_time() {
+  date +%s
+}
+
+get_cache_val(){
+  local key="$1"
+  # seconds after which cache is invalidated
+  local timeout="${2:-2}"
+  local cache="$(get_tmp_dir)/$key"
+  if [ -f "$cache" ]; then
+    awk -v cache="$(head -n1 "$cache")" -v timeout=$timeout -v now=$(get_time) \
+      'BEGIN {if (now - timeout < cache) exit 0; exit 1}' \
+      && tail -n+2 "$cache"
+  fi
+}
+
+put_cache_val(){
+  local key="$1"
+  local val="${@:2}"
+  local tmpdir="$(get_tmp_dir)"
+  [ ! -d "$tmpdir" ] && mkdir -p "$tmpdir" && chmod 0700 "$tmpdir"
+  echo "$(get_time)" > "$tmpdir/$key"
+  echo -n "$val" >> "$tmpdir/$key"
+  echo -n "$val"
+}
+
+cached_eval(){
+  local command="$1"
+  local key="$(basename "$command")"
+  local val="$(get_cache_val "$key")"
+  if [ -z "$val" ]; then
+    put_cache_val "$key" "$($command "${@:2}")"
+  else
+    echo -n "$val"
+  fi
+}

--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -17,10 +17,10 @@ print_ram_percentage() {
   ram_percentage_format=$(get_tmux_option "@ram_percentage_format" "$ram_percentage_format")
 
   if command_exists "free"; then
-    free | awk -v format="$ram_percentage_format" '$1 ~ /Mem/ {printf(format, 100*$3/$2)}'
+    cached_eval free | awk -v format="$ram_percentage_format" '$1 ~ /Mem/ {printf(format, 100*$3/$2)}'
   elif command_exists "vm_stat"; then
     # page size of 4096 bytes
-    stats="$(vm_stat)"
+    stats="$(cached_eval vm_stat)"
 
     used_and_cached=$(echo "$stats" \
       | grep -E "(Pages active|Pages inactive|Pages speculative|Pages wired down|Pages occupied by compressor)" \


### PR DESCRIPTION
Attempts to cache runs of underlying commands so that e.g. `#{gpu_bg_color}#{gpu_percentage}` only calls `nvidia-smi` once per update.

- fixes #27
- also fixes (maybe) #5
- related #15

Notes:

- runs cached commands a maximum of once every 2 seconds
- caches based on `date +%s` and `basename command`, ignoring command arguments. This could be a problem if running the same command with different arguments (not currently a problem)

## details

While testing this, I think I've found an upstream problem (with `tmux` or `tpm`). Basically

```bash
set -g status-right "%H:%M:%S #(sleep 1)"
set -g status-interval 5
```

will ignore `status-interval` and result in one update per second (!) which appears to be #15.

1. #15 (`status-interval` not respected) looks like an upstream bug
2. each update, commands may be run in parallel? e.g. `set -g status-right #(write_hello_to_debug_file) #(write_bye_to_debug_file)` won't guarantee `hello` is written before `bye`. This means that caching within an update may not work. Needs investigating... it's possible that some higher level code (outside this repo) handles caching of `#(external commands)`
3. oddly, before this PR, I get updates more than 1/s, but after it's about once every 5 sec, respecting `status-interval`. This seems to fix (maybe) #15 but no there's not clear reason why... I suspect some higher level logic may be doing something like:
	```python
	commands = find_pattern("#(*)", status_right)
	while True:
	    execution_time = exec(commands)
	    if execution_time < 1:
	        sleep(status_interval)
	```

### debugging

in `~/.tmux.conf`:

```bash
set -g status-right '#{cpu_bg_color}#{cpu_percentage}#[bg=green][#{ram_bg_color}#{ram_percentage}#[bg=green]] #{gpu_bg_color}#{gpu_percentage}#[bg=green][#{gram_bg_color}#{gram_percentage}#[bg=green]]'
```

print to a debug file in `~/.tmux/plugins/tmux-cpu/debug.log`:

```patch
diff --git a/scripts/helpers.sh b/scripts/helpers.sh
index df31cfb..d1e3e84 100644
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -99,7 +99,9 @@ cached_eval(){
   local val="$(get_cache_val "$key")"
   if [ -z "$val" ]; then
     put_cache_val "$key" "$($command "${@:2}")"
+    echo miss "$key" >> ~/.tmux/plugins/tmux-cpu/debug.log
   else
     echo -n "$val"
+    echo hit "$key" >> ~/.tmux/plugins/tmux-cpu/debug.log
   fi
 }
```

- observation: will print `miss nvidia-smi` 4 times in quick succession each update
- expected: `miss nvidia-smi` once, then `hit nvidia-smi` 3 times

```bash
tail -f ~/.tmux/plugins/tmux-cpu/debug.log
```