### PR TITLE
allow pattern to be reused multiple times

### DIFF
--- a/cpu.tmux
+++ b/cpu.tmux
@@ -50,7 +50,7 @@ set_tmux_option() {
 do_interpolation() {
   local all_interpolated="$1"
   for ((i=0; i<${#cpu_commands[@]}; i++)); do
-    all_interpolated=${all_interpolated/${cpu_interpolation[$i]}/${cpu_commands[$i]}}
+    all_interpolated=${all_interpolated//${cpu_interpolation[$i]}/${cpu_commands[$i]}}
   done
   echo "$all_interpolated"
 }


### PR DESCRIPTION
For example, if we want to have a CPU percentage show on the left status twice, we cannot do that since the interpolation only done for the first occurrence of the pattern.

This PR allow the pattern to be reused multiple times.