### PR TITLE
Add CPU and GPU temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Here are all available options with their default values:
 @cpu_temp_(low_icon,high_bg_color,etc...) # same defaults as above
 ```
 
-All `@cpu_*` options are valid with `@gpu_*`. Additionally, `@ram_*` options become `@gram_*` for GPU equivalents.
+All `@cpu_*` options are valid with `@gpu_*` (except `@cpu_*_thresh` which apply to both CPU and GPU). Additionally, `@ram_*` options become `@gram_*` for GPU equivalents.
 
 Note that these colors depend on your terminal / X11 config.
 

--- a/README.md
+++ b/README.md
@@ -39,17 +39,16 @@ $ tmux source-file ~/.tmux.conf
 
 If format strings are added to `status-right`, they should now be visible.
 
-### Optional requirement (Linux, BSD, OSX)
+### Optional requirements (Linux, BSD, OSX)
 
-`iostat` or `sar` are the best way to get an accurate CPU percentage.
+- `iostat` or `sar` are the best way to get an accurate CPU percentage.
 A fallback is included using `ps -aux` but could be inaccurate.
-`free` is used for obtaining system RAM status.
-`nvidia-smi` is required for GPU information.
-For OSX, `cuda-smi` is required instead (but only shows GPU memory use rather
-than load).
-
-If 'No GPU' is displayed, it means the script was not able to find `nvidia-smi`/`cuda-smi`.
-Please make sure the appropriate command is installed and in PATH.
+- `free` is used for obtaining system RAM status.
+- `lm-sensors` is used for CPU temperature.
+- `nvidia-smi` is required for GPU information.
+For OSX, `cuda-smi` is required instead (but only shows GPU memory use rather than load).
+If "No GPU" is displayed, it means the script was not able to find `nvidia-smi`/`cuda-smi`.
+Please make sure the appropriate command is installed and in the `$PATH`.
 
 ## Usage
 
@@ -63,7 +62,7 @@ set -g status-right '#{cpu_bg_color} CPU: #{cpu_icon} #{cpu_percentage} | %a %h-
 
 ### Supported Options
 
-This is done by introducing 8 new format strings that can be added to
+This is done by introducing 12 new format strings that can be added to
 `status-right` option:
 
 - `#{cpu_icon}` - will display a CPU status icon
@@ -133,14 +132,18 @@ Here are all available options with their default values:
 @cpu_medium_thresh "30" # medium percentage threshold
 @cpu_high_thresh "80" # high percentage threshold
 
+@ram_(low_icon,high_bg_color,etc...) # same defaults as above
+
 @cpu_temp_format "%2.0f" # printf format to use to display temperature
 @cpu_temp_units "C" # supports C & F
 
 @cpu_temp_medium_thresh "80" # medium temperature threshold
 @cpu_temp_high_thresh "90" # high temperature threshold
+
+@cpu_temp_(low_icon,high_bg_color,etc...) # same defaults as above
 ```
 
-Same options are valid with `@gpu`
+All `@cpu_*` options are valid with `@gpu_*`. Additionally, `@ram_*` options become `@gram_*` for GPU equivalents.
 
 Note that these colors depend on your terminal / X11 config.
 
@@ -151,8 +154,7 @@ set -g @cpu_low_fg_color "#[fg=#00ff00]"
 set -g @cpu_percentage_format "%5.1f%%" # Add left padding
 ```
 
-Don't forget to reload tmux environment (`$ tmux source-file ~/.tmux.conf`)
-after you do this.
+Don't forget to reload the tmux environment (`$ tmux source-file ~/.tmux.conf`) after you do this.
 
 ### Tmux Plugins
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ GPU equivalents also exist:
 - `#{gram_percentage}` - will show GPU RAM percentage (total across devices)
 - `#{gram_bg_color}` - will change the background color based on the GPU RAM percentage
 - `#{gram_fg_color}` - will change the foreground color based on the GPU RAM percentage
+- `#{gpu_temp_icon}` - will display a GPU temperature status icon
+- `#{gpu_temp}` - will show GPU temperature (average across devices)
+- `#{gpu_temp_bg_color}` - will change the background color based on the GPU temperature
+- `#{gpu_temp_fg_color}` - will change the foreground color based on the GPU temperature
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ This is done by introducing 8 new format strings that can be added to
 - `#{ram_percentage}` - will show RAM percentage (averaged across cores)
 - `#{ram_bg_color}` - will change the background color based on the RAM percentage
 - `#{ram_fg_color}` - will change the foreground color based on the RAM percentage
+- `#{cpu_temp_icon}` - will display a CPU temperature status icon
+- `#{cpu_temp}` - will show CPU temperature (averaged across cores)
+- `#{cpu_temp_bg_color}` - will change the background color based on the CPU temperature
+- `#{cpu_temp_fg_color}` - will change the foreground color based on the CPU temperature
 
 GPU equivalents also exist:
 
@@ -124,6 +128,12 @@ Here are all available options with their default values:
 
 @cpu_medium_thresh "30" # medium percentage threshold
 @cpu_high_thresh "80" # high percentage threshold
+
+@cpu_temp_format "%2.0f" # printf format to use to display temperature
+@cpu_temp_units "C" # supports C & F
+
+@cpu_temp_medium_thresh "80" # medium temperature threshold
+@cpu_temp_high_thresh "90" # high temperature threshold
 ```
 
 Same options are valid with `@gpu`

--- a/cpu.tmux
+++ b/cpu.tmux
@@ -22,6 +22,9 @@ cpu_interpolation=(
   "\#{gram_bg_color}"
   "\#{gram_fg_color}"
   "\#{cpu_temp}"
+  "\#{cpu_temp_icon}"
+  "\#{cpu_temp_bg_color}"
+  "\#{cpu_temp_fg_color}"
 )
 cpu_commands=(
   "#($CURRENT_DIR/scripts/cpu_percentage.sh)"
@@ -41,6 +44,9 @@ cpu_commands=(
   "#($CURRENT_DIR/scripts/gram_bg_color.sh)"
   "#($CURRENT_DIR/scripts/gram_fg_color.sh)"
   "#($CURRENT_DIR/scripts/cpu_temp.sh)"
+  "#($CURRENT_DIR/scripts/cpu_temp_icon.sh)"
+  "#($CURRENT_DIR/scripts/cpu_temp_bg_color.sh)"
+  "#($CURRENT_DIR/scripts/cpu_temp_fg_color.sh)"
 )
 
 set_tmux_option() {

--- a/cpu.tmux
+++ b/cpu.tmux
@@ -21,6 +21,7 @@ cpu_interpolation=(
   "\#{gram_icon}"
   "\#{gram_bg_color}"
   "\#{gram_fg_color}"
+  "\#{cpu_temp}"
 )
 cpu_commands=(
   "#($CURRENT_DIR/scripts/cpu_percentage.sh)"
@@ -39,6 +40,7 @@ cpu_commands=(
   "#($CURRENT_DIR/scripts/gram_icon.sh)"
   "#($CURRENT_DIR/scripts/gram_bg_color.sh)"
   "#($CURRENT_DIR/scripts/gram_fg_color.sh)"
+  "#($CURRENT_DIR/scripts/cpu_temp.sh)"
 )
 
 set_tmux_option() {

--- a/cpu.tmux
+++ b/cpu.tmux
@@ -25,6 +25,10 @@ cpu_interpolation=(
   "\#{cpu_temp_icon}"
   "\#{cpu_temp_bg_color}"
   "\#{cpu_temp_fg_color}"
+  "\#{gpu_temp}"
+  "\#{gpu_temp_icon}"
+  "\#{gpu_temp_bg_color}"
+  "\#{gpu_temp_fg_color}"
 )
 cpu_commands=(
   "#($CURRENT_DIR/scripts/cpu_percentage.sh)"
@@ -47,6 +51,10 @@ cpu_commands=(
   "#($CURRENT_DIR/scripts/cpu_temp_icon.sh)"
   "#($CURRENT_DIR/scripts/cpu_temp_bg_color.sh)"
   "#($CURRENT_DIR/scripts/cpu_temp_fg_color.sh)"
+  "#($CURRENT_DIR/scripts/gpu_temp.sh)"
+  "#($CURRENT_DIR/scripts/gpu_temp_icon.sh)"
+  "#($CURRENT_DIR/scripts/gpu_temp_bg_color.sh)"
+  "#($CURRENT_DIR/scripts/gpu_temp_fg_color.sh)"
 )
 
 set_tmux_option() {

--- a/scripts/cpu_icon.sh
+++ b/scripts/cpu_icon.sh
@@ -34,7 +34,6 @@ print_icon() {
 
 main() {
   get_icon_settings
-  local cpu_icon=$(print_icon "$1")
-  echo "$cpu_icon"
+  print_icon "$1"
 }
 main

--- a/scripts/cpu_temp.sh
+++ b/scripts/cpu_temp.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+cpu_temp_format="%2.0f"
+cpu_temp_unit="C"
+
+print_cpu_temp() {
+  cpu_temp_format=$(get_tmux_option "@cpu_temp_format" "$cpu_temp_format")
+  cpu_temp_unit=$(get_tmux_option "@cpu_temp_unit" "$cpu_temp_unit")
+  if command_exists "sensors"; then
+    ([ "$cpu_temp_unit" == F ] && sensors -f || sensors) | awk -v format="$cpu_temp_format$cpu_temp_unit" '/^Core [0-9]+/ {gsub("[^0-9.]", "", $3); sum+=$3; n+=1} END {printf(format, sum/n)}'
+  fi
+}
+
+main() {
+  print_cpu_temp
+}
+main

--- a/scripts/cpu_temp_bg_color.sh
+++ b/scripts/cpu_temp_bg_color.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+cpu_temp_low_bg_color=""
+cpu_temp_medium_bg_color=""
+cpu_temp_high_bg_color=""
+
+cpu_temp_low_default_bg_color="#[bg=green]"
+cpu_temp_medium_default_bg_color="#[bg=yellow]"
+cpu_temp_high_default_bg_color="#[bg=red]"
+
+get_bg_color_settings() {
+  cpu_temp_low_bg_color=$(get_tmux_option "@cpu_temp_low_bg_color" "$cpu_temp_low_default_bg_color")
+  cpu_temp_medium_bg_color=$(get_tmux_option "@cpu_temp_medium_bg_color" "$cpu_temp_medium_default_bg_color")
+  cpu_temp_high_bg_color=$(get_tmux_option "@cpu_temp_high_bg_color" "$cpu_temp_high_default_bg_color")
+}
+
+print_bg_color() {
+  local cpu_temp=$($CURRENT_DIR/cpu_temp.sh | sed -e 's/[^0-9.]//')
+  local cpu_temp_status=$(temp_status $cpu_temp)
+  if [ $cpu_temp_status == "low" ]; then
+    echo "$cpu_temp_low_bg_color"
+  elif [ $cpu_temp_status == "medium" ]; then
+    echo "$cpu_temp_medium_bg_color"
+  elif [ $cpu_temp_status == "high" ]; then
+    echo "$cpu_temp_high_bg_color"
+  fi
+}
+
+main() {
+  get_bg_color_settings
+  print_bg_color
+}
+main

--- a/scripts/cpu_temp_fg_color.sh
+++ b/scripts/cpu_temp_fg_color.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+cpu_temp_low_fg_color=""
+cpu_temp_medium_fg_color=""
+cpu_temp_high_fg_color=""
+
+cpu_temp_low_default_fg_color="#[bg=green]"
+cpu_temp_medium_default_fg_color="#[bg=yellow]"
+cpu_temp_high_default_fg_color="#[bg=red]"
+
+get_fg_color_settings() {
+  cpu_temp_low_fg_color=$(get_tmux_option "@cpu_temp_low_fg_color" "$cpu_temp_low_default_fg_color")
+  cpu_temp_medium_fg_color=$(get_tmux_option "@cpu_temp_medium_fg_color" "$cpu_temp_medium_default_fg_color")
+  cpu_temp_high_fg_color=$(get_tmux_option "@cpu_temp_high_fg_color" "$cpu_temp_high_default_fg_color")
+}
+
+print_fg_color() {
+  local cpu_temp=$($CURRENT_DIR/cpu_temp.sh | sed -e 's/[^0-9.]//')
+  local cpu_temp_status=$(temp_status $cpu_temp)
+  if [ $cpu_temp_status == "low" ]; then
+    echo "$cpu_temp_low_fg_color"
+  elif [ $cpu_temp_status == "medium" ]; then
+    echo "$cpu_temp_medium_fg_color"
+  elif [ $cpu_temp_status == "high" ]; then
+    echo "$cpu_temp_high_fg_color"
+  fi
+}
+
+main() {
+  get_fg_color_settings
+  print_fg_color
+}
+main

--- a/scripts/cpu_temp_icon.sh
+++ b/scripts/cpu_temp_icon.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+# script global variables
+cpu_temp_low_icon=""
+cpu_temp_medium_icon=""
+cpu_temp_high_icon=""
+
+cpu_temp_low_default_icon="="
+cpu_temp_medium_default_icon="≡"
+cpu_temp_high_default_icon="≣"
+
+# icons are set as script global variables
+get_icon_settings() {
+  cpu_temp_low_icon=$(get_tmux_option "@cpu_temp_low_icon" "$cpu_temp_low_default_icon")
+  cpu_temp_medium_icon=$(get_tmux_option "@cpu_temp_medium_icon" "$cpu_temp_medium_default_icon")
+  cpu_temp_high_icon=$(get_tmux_option "@cpu_temp_high_icon" "$cpu_temp_high_default_icon")
+}
+
+print_icon() {
+  local cpu_temp=$($CURRENT_DIR/cpu_temp.sh | sed -e 's/[^0-9.]//')
+  local cpu_temp_status=$(temp_status $cpu_temp)
+  if [ $cpu_temp_status == "low" ]; then
+    echo "$cpu_temp_low_icon"
+  elif [ $cpu_temp_status == "medium" ]; then
+    echo "$cpu_temp_medium_icon"
+  elif [ $cpu_temp_status == "high" ]; then
+    echo "$cpu_temp_high_icon"
+  fi
+}
+
+main() {
+  get_icon_settings
+  local cpu_temp_icon=$(print_icon "$1")
+  echo "$cpu_temp_icon"
+}
+main

--- a/scripts/cpu_temp_icon.sh
+++ b/scripts/cpu_temp_icon.sh
@@ -34,7 +34,6 @@ print_icon() {
 
 main() {
   get_icon_settings
-  local cpu_temp_icon=$(print_icon "$1")
-  echo "$cpu_temp_icon"
+  print_icon "$1"
 }
 main

--- a/scripts/gpu_icon.sh
+++ b/scripts/gpu_icon.sh
@@ -34,7 +34,6 @@ print_icon() {
 
 main() {
   get_icon_settings
-  local gpu_icon=$(print_icon "$1")
-  echo "$gpu_icon"
+  print_icon "$1"
 }
 main

--- a/scripts/gpu_percentage.sh
+++ b/scripts/gpu_percentage.sh
@@ -17,10 +17,7 @@ print_gpu_percentage() {
     echo "No GPU"
     return
   fi
-  loads=$(echo "$loads" | sed -nr 's/.*\s([0-9]+)%.*/\1/p')
-  gpus=$(echo "$loads" | wc -l)
-  load=$(echo "$loads" | awk '{count+=$1} END {print count}')
-  echo "$load $gpus" | awk -v format="$gpu_percentage_format" '{printf format, $1/$2}'
+  echo "$loads" | sed -nr 's/.*\s([0-9]+)%.*/\1/p' | awk -v format="$gpu_percentage_format" '{sum+=$1; n+=1} END {printf format, sum/n}'
 }
 
 main() {

--- a/scripts/gpu_temp.sh
+++ b/scripts/gpu_temp.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+gpu_temp_format="%2.0f"
+
+print_gpu_temp() {
+  gpu_temp_format=$(get_tmux_option "@gpu_temp_format" "$gpu_temp_format")
+
+  if command_exists "nvidia-smi"; then
+    loads=$(cached_eval nvidia-smi)
+  elif command_exists "cuda-smi"; then
+    loads=$(cached_eval cuda-smi)
+  else
+    echo "No GPU"
+    return
+  fi
+  echo "$loads" | sed -nr 's/.*\s([0-9]+)C.*/\1/p' | awk -v format="${gpu_temp_format}C" '{sum+=$1; n+=1} END {printf format, sum/n}'
+}
+
+main() {
+  print_gpu_temp
+}
+main

--- a/scripts/gpu_temp_bg_color.sh
+++ b/scripts/gpu_temp_bg_color.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+gpu_temp_low_bg_color=""
+gpu_temp_medium_bg_color=""
+gpu_temp_high_bg_color=""
+
+gpu_temp_low_default_bg_color="#[bg=green]"
+gpu_temp_medium_default_bg_color="#[bg=yellow]"
+gpu_temp_high_default_bg_color="#[bg=red]"
+
+get_bg_color_settings() {
+  gpu_temp_low_bg_color=$(get_tmux_option "@gpu_temp_low_bg_color" "$gpu_temp_low_default_bg_color")
+  gpu_temp_medium_bg_color=$(get_tmux_option "@gpu_temp_medium_bg_color" "$gpu_temp_medium_default_bg_color")
+  gpu_temp_high_bg_color=$(get_tmux_option "@gpu_temp_high_bg_color" "$gpu_temp_high_default_bg_color")
+}
+
+print_bg_color() {
+  local gpu_temp=$($CURRENT_DIR/gpu_temp.sh | sed -e 's/[^0-9.]//')
+  local gpu_temp_status=$(temp_status $gpu_temp)
+  if [ $gpu_temp_status == "low" ]; then
+    echo "$gpu_temp_low_bg_color"
+  elif [ $gpu_temp_status == "medium" ]; then
+    echo "$gpu_temp_medium_bg_color"
+  elif [ $gpu_temp_status == "high" ]; then
+    echo "$gpu_temp_high_bg_color"
+  fi
+}
+
+main() {
+  get_bg_color_settings
+  print_bg_color
+}
+main

--- a/scripts/gpu_temp_fg_color.sh
+++ b/scripts/gpu_temp_fg_color.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+gpu_temp_low_fg_color=""
+gpu_temp_medium_fg_color=""
+gpu_temp_high_fg_color=""
+
+gpu_temp_low_default_fg_color="#[bg=green]"
+gpu_temp_medium_default_fg_color="#[bg=yellow]"
+gpu_temp_high_default_fg_color="#[bg=red]"
+
+get_fg_color_settings() {
+  gpu_temp_low_fg_color=$(get_tmux_option "@gpu_temp_low_fg_color" "$gpu_temp_low_default_fg_color")
+  gpu_temp_medium_fg_color=$(get_tmux_option "@gpu_temp_medium_fg_color" "$gpu_temp_medium_default_fg_color")
+  gpu_temp_high_fg_color=$(get_tmux_option "@gpu_temp_high_fg_color" "$gpu_temp_high_default_fg_color")
+}
+
+print_fg_color() {
+  local gpu_temp=$($CURRENT_DIR/gpu_temp.sh | sed -e 's/[^0-9.]//')
+  local gpu_temp_status=$(temp_status $gpu_temp)
+  if [ $gpu_temp_status == "low" ]; then
+    echo "$gpu_temp_low_fg_color"
+  elif [ $gpu_temp_status == "medium" ]; then
+    echo "$gpu_temp_medium_fg_color"
+  elif [ $gpu_temp_status == "high" ]; then
+    echo "$gpu_temp_high_fg_color"
+  fi
+}
+
+main() {
+  get_fg_color_settings
+  print_fg_color
+}
+main

--- a/scripts/gpu_temp_icon.sh
+++ b/scripts/gpu_temp_icon.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+# script global variables
+gpu_temp_low_icon=""
+gpu_temp_medium_icon=""
+gpu_temp_high_icon=""
+
+gpu_temp_low_default_icon="="
+gpu_temp_medium_default_icon="≡"
+gpu_temp_high_default_icon="≣"
+
+# icons are set as script global variables
+get_icon_settings() {
+  gpu_temp_low_icon=$(get_tmux_option "@gpu_temp_low_icon" "$gpu_temp_low_default_icon")
+  gpu_temp_medium_icon=$(get_tmux_option "@gpu_temp_medium_icon" "$gpu_temp_medium_default_icon")
+  gpu_temp_high_icon=$(get_tmux_option "@gpu_temp_high_icon" "$gpu_temp_high_default_icon")
+}
+
+print_icon() {
+  local gpu_temp=$($CURRENT_DIR/gpu_temp.sh | sed -e 's/[^0-9.]//')
+  local gpu_temp_status=$(temp_status $gpu_temp)
+  if [ $gpu_temp_status == "low" ]; then
+    echo "$gpu_temp_low_icon"
+  elif [ $gpu_temp_status == "medium" ]; then
+    echo "$gpu_temp_medium_icon"
+  elif [ $gpu_temp_status == "high" ]; then
+    echo "$gpu_temp_high_icon"
+  fi
+}
+
+main() {
+  get_icon_settings
+  print_icon "$1"
+}
+main

--- a/scripts/gram_icon.sh
+++ b/scripts/gram_icon.sh
@@ -34,7 +34,6 @@ print_icon() {
 
 main() {
   get_icon_settings
-  local gram_icon=$(print_icon "$1")
-  echo "$gram_icon"
+  print_icon "$1"
 }
 main

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -55,6 +55,19 @@ load_status() {
   fi
 }
 
+temp_status() {
+  local temp=$1
+  cpu_medium_thresh=$(get_tmux_option "@cpu_temp_medium_thresh" "80")
+  cpu_high_thresh=$(get_tmux_option "@cpu_temp_high_thresh" "90")
+  if fcomp $cpu_temp_high_thresh $temp; then
+    echo "high"
+  elif fcomp $cpu_temp_medium_thresh $temp && fcomp $temp $cpu_temp_high_thresh; then
+    echo "medium"
+  else
+    echo "low"
+  fi
+}
+
 cpus_number() {
   if is_linux; then
     nproc

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -57,8 +57,8 @@ load_status() {
 
 temp_status() {
   local temp=$1
-  cpu_medium_thresh=$(get_tmux_option "@cpu_temp_medium_thresh" "80")
-  cpu_high_thresh=$(get_tmux_option "@cpu_temp_high_thresh" "90")
+  cpu_temp_medium_thresh=$(get_tmux_option "@cpu_temp_medium_thresh" "80")
+  cpu_temp_high_thresh=$(get_tmux_option "@cpu_temp_high_thresh" "90")
   if fcomp $cpu_temp_high_thresh $temp; then
     echo "high"
   elif fcomp $cpu_temp_medium_thresh $temp && fcomp $temp $cpu_temp_high_thresh; then

--- a/scripts/ram_icon.sh
+++ b/scripts/ram_icon.sh
@@ -34,7 +34,6 @@ print_icon() {
 
 main() {
   get_icon_settings
-  local ram_icon=$(print_icon "$1")
-  echo "$ram_icon"
+  print_icon "$1"
 }
 main


### PR DESCRIPTION
- [x] add CPU temperature
  + haven't done Mac since I don't have one to test on, and online resources don't seem to agree on what's the best way; can leave it for a later PR
- [x] add GPU temperature
  + haven't bothered implementing ~barbaric~ Fahrenheit units; `nvidia-smi` doesn't output them; can leave it for a later PR
- add format/icons/fg&bg colours/format for both of the above
- add documentation for all of the aboe
- slight code tidy
- misc documentation improvements

CPU & GPU `use[ram](temp)`: ![image](https://user-images.githubusercontent.com/10780059/96355736-ed004700-10dc-11eb-8690-16833082950a.png)