### PR TITLE
temp: add `@gpu_temp_unit`, support AMD CPU, fix docs

### DIFF
--- a/scripts/cpu_temp.sh
+++ b/scripts/cpu_temp.sh
@@ -11,7 +11,7 @@ print_cpu_temp() {
   cpu_temp_format=$(get_tmux_option "@cpu_temp_format" "$cpu_temp_format")
   cpu_temp_unit=$(get_tmux_option "@cpu_temp_unit" "$cpu_temp_unit")
   if command_exists "sensors"; then
-    ([ "$cpu_temp_unit" == F ] && sensors -f || sensors) | awk -v format="$cpu_temp_format$cpu_temp_unit" '/^Core [0-9]+/ {gsub("[^0-9.]", "", $3); sum+=$3; n+=1} END {printf(format, sum/n)}'
+    ([ "$cpu_temp_unit" == F ] && sensors -f || sensors) | sed -e 's/^Tccd/Core /' | awk -v format="$cpu_temp_format$cpu_temp_unit" '/^Core [0-9]+/ {gsub("[^0-9.]", "", $3); sum+=$3; n+=1} END {printf(format, sum/n)}'
   fi
 }
 

--- a/scripts/gpu_temp.sh
+++ b/scripts/gpu_temp.sh
@@ -5,9 +5,11 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 gpu_temp_format="%2.0f"
+gpu_temp_unit="C"
 
 print_gpu_temp() {
   gpu_temp_format=$(get_tmux_option "@gpu_temp_format" "$gpu_temp_format")
+  gpu_temp_unit=$(get_tmux_option "@gpu_temp_unit" "$gpu_temp_unit")
 
   if command_exists "nvidia-smi"; then
     loads=$(cached_eval nvidia-smi)
@@ -17,7 +19,12 @@ print_gpu_temp() {
     echo "No GPU"
     return
   fi
-  echo "$loads" | sed -nr 's/.*\s([0-9]+)C.*/\1/p' | awk -v format="${gpu_temp_format}C" '{sum+=$1; n+=1} END {printf format, sum/n}'
+  tempC=$(echo "$loads" | sed -nr 's/.*\s([0-9]+)C.*/\1/p' | awk '{sum+=$1; n+=1} END {printf "%5.3f", sum/n}')
+  if [ $gpu_temp_unit == "C" ]; then
+    echo "$tempC" | awk -v format="${gpu_temp_format}C" '{sum+=$1} END {printf format, sum}'
+  else
+    echo "$tempC" | awk -v format="${gpu_temp_format}F" '{sum+=$1} END {printf format, sum*9/5+32}'
+  fi
 }
 
 main() {


### PR DESCRIPTION
- add `@gpu_temp_unit` support for "F"
- document config option `@cpu_temp_unit` (not `@cpu_temp_units`)
- support AMD Ryzen CPU temp

----

- fixes #66