### PR TITLE
When getting a tmux option, first check session option

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -4,7 +4,10 @@ export LC_ALL=C
 get_tmux_option() {
   local option="$1"
   local default_value="$2"
-  local option_value="$(tmux show-option -gqv "$option")"
+  local option_value="$(tmux show-option -qv "$option")"
+  if [ -z "$option_value" ]; then
+    option_value="$(tmux show-option -gqv "$option")"
+  fi
   if [ -z "$option_value" ]; then
     echo "$default_value"
   else


### PR DESCRIPTION
It seems logical to check session options, failing which, then, check
global options. This allows, for example, per-session customization of
the color tmux variables.
