### PR TITLE
fix gram_percentage.sh when showing ram usage of multi GPUs

### DIFF
--- a/scripts/gram_percentage.sh
+++ b/scripts/gram_percentage.sh
@@ -18,7 +18,7 @@ print_gram_percentage() {
     echo "No GPU"
     return
   fi
-  echo "$loads" | awk -v format="$gram_percentage_format" '{used+=$1; tot+=$2} END {printf format, 100*$1/$2}'
+  echo "$loads" | awk -v format="$gram_percentage_format" '{used+=$1; tot+=$2} END {printf format, 100*used/tot}'
 }
 
 main() {


### PR DESCRIPTION
This PR fixed gram_percentage.sh script which only shows the ram usage of the last GPU  
showed from nvidia-smi in multi-GPU computer.


