### PR TITLE
helpers: fix non-atomic cache write

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -130,8 +130,10 @@ put_cache_val() {
   val="${*:2}"
   tmpdir="$(get_tmp_dir)"
   [ ! -d "$tmpdir" ] && mkdir -p "$tmpdir" && chmod 0700 "$tmpdir"
-  get_time >"$tmpdir/$key"
-  echo -n "$val" >>"$tmpdir/$key"
+  (
+    get_time
+    echo -n "$val"
+  ) >"$tmpdir/$key"
   echo -n "$val"
 }
 


### PR DESCRIPTION
This was causing some values to be repeated more than once when using
multiple tmux windows at the same time, for example for the RAM
percentage in ram_percentage.sh.

GitHub: fixes #62
