### PR TITLE
Added WSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ If you're running on WSL you can set these options to get the CPU / RAM values f
 @ram_wsl 'true  # true/false
 ```
 
+Note this only works if `$WSL_DISTRO_NAME` is also set, which is done by default inside WSL.
+
 ### Tmux Plugins
 
 This plugin is part of the [tmux-plugins](https://github.com/tmux-plugins) organisation. Checkout plugins as [battery](https://github.com/tmux-plugins/tmux-battery), [logging](https://github.com/tmux-plugins/tmux-logging), [online status](https://github.com/tmux-plugins/tmux-online-status), and many more over at the [tmux-plugins](https://github.com/tmux-plugins) organisation page.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ set -g @cpu_percentage_format "%5.1f%%" # Add left padding
 
 Don't forget to reload the tmux environment (`$ tmux source-file ~/.tmux.conf`) after you do this.
 
+### WSL support
+
+If you're running on WSL you can set these options to get the CPU / RAM values from the Windows host system instead:
+
+```shell
+@cpu_wsl 'true' # true/false
+@ram_wsl 'true  # true/false
+```
+
 ### Tmux Plugins
 
 This plugin is part of the [tmux-plugins](https://github.com/tmux-plugins) organisation. Checkout plugins as [battery](https://github.com/tmux-plugins/tmux-battery), [logging](https://github.com/tmux-plugins/tmux-logging), [online status](https://github.com/tmux-plugins/tmux-online-status), and many more over at the [tmux-plugins](https://github.com/tmux-plugins) organisation page.

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Don't forget to reload the tmux environment (`$ tmux source-file ~/.tmux.conf`) 
 If you're running on WSL you can set these options to get the CPU / RAM values from the Windows host system instead:
 
 ```shell
-@cpu_wsl 'true' # true/false
-@ram_wsl 'true  # true/false
+@cpu_wsl_host 'true' # true/false
+@ram_wsl_host 'true  # true/false
 ```
 
 Note this only works if `$WSL_DISTRO_NAME` is also set, which is done by default inside WSL.

--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -10,7 +10,10 @@ cpu_percentage_format="%3.1f%%"
 print_cpu_percentage() {
   cpu_percentage_format=$(get_tmux_option "@cpu_percentage_format" "$cpu_percentage_format")
 
-  if command_exists "iostat"; then
+  if $(get_tmux_option @cpu_wsl) == "true" ; then
+      load="$(cached_eval wmic.exe cpu get LoadPercentage | grep -Eo '^[0-9]+')"
+      echo "$load" | awk -v format="$cpu_percentage_format" '{printf format, $1}'
+  elif command_exists "iostat"; then
 
     if is_linux_iostat; then
       cached_eval iostat -c 1 2 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'

--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -10,7 +10,7 @@ cpu_percentage_format="%3.1f%%"
 print_cpu_percentage() {
   cpu_percentage_format=$(get_tmux_option "@cpu_percentage_format" "$cpu_percentage_format")
 
-  if $(get_tmux_option @cpu_wsl) == "true" ; then
+  if $(get_tmux_option @cpu_wsl) == "true" && test -n "${WSL_DISTRO_NAME}" ; then
       load="$(cached_eval wmic.exe cpu get LoadPercentage | grep -Eo '^[0-9]+')"
       echo "$load" | awk -v format="$cpu_percentage_format" '{printf format, $1}'
   elif command_exists "iostat"; then

--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -10,7 +10,7 @@ cpu_percentage_format="%3.1f%%"
 print_cpu_percentage() {
   cpu_percentage_format=$(get_tmux_option "@cpu_percentage_format" "$cpu_percentage_format")
 
-  if $(get_tmux_option @cpu_wsl) == "true" && test -n "${WSL_DISTRO_NAME}" ; then
+  if [[ $(get_tmux_option @cpu_wsl_host) == "true" && -n "${WSL_DISTRO_NAME}" ]] ; then
       load="$(cached_eval wmic.exe cpu get LoadPercentage | grep -Eo '^[0-9]+')"
       echo "$load" | awk -v format="$cpu_percentage_format" '{printf format, $1}'
   elif command_exists "iostat"; then

--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -19,8 +19,8 @@ print_ram_percentage() {
 
     # TotalPhysicalMemory is in bytes, but FreePhysicalMemory is in KiB
     total=$(wmic.exe ComputerSystem get TotalPhysicalMemory | awk '/^[0-9]/{print $1/1024}')
-    used=$(wmic.exe OS get FreePhysicalMemory | awk '/^[0-9]/{print $1}')
-
+    free=$(wmic.exe OS get freevirtualmemory | awk '/^[0-9]/{print $1}')
+    used=$(($total - $free))
     echo "$used $total" | awk -v format="$ram_percentage_format" '{printf(format, 100*$1/$2)}'
 
   elif command_exists "free"; then

--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -15,7 +15,7 @@ sum_macos_vm_stats() {
 print_ram_percentage() {
   ram_percentage_format=$(get_tmux_option "@ram_percentage_format" "$ram_percentage_format")
 
-  if $(get_tmux_option @ram_wsl) == "true" ; then
+  if $(get_tmux_option @ram_wsl) == "true" && test -n "${WSL_DISTRO_NAME}"; then
 
     # TotalPhysicalMemory is in bytes, but FreePhysicalMemory is in KiB
     total=$(wmic.exe ComputerSystem get TotalPhysicalMemory | awk '/^[0-9]/{print $1/1024}')

--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -15,7 +15,15 @@ sum_macos_vm_stats() {
 print_ram_percentage() {
   ram_percentage_format=$(get_tmux_option "@ram_percentage_format" "$ram_percentage_format")
 
-  if command_exists "free"; then
+  if $(get_tmux_option @ram_wsl) == "true" ; then
+
+    # TotalPhysicalMemory is in bytes, but FreePhysicalMemory is in KiB
+    total=$(wmic.exe ComputerSystem get TotalPhysicalMemory | awk '/^[0-9]/{print $1/1024}')
+    used=$(wmic.exe OS get FreePhysicalMemory | awk '/^[0-9]/{print $1}')
+
+    echo "$used $total" | awk -v format="$ram_percentage_format" '{printf(format, 100*$1/$2)}'
+
+  elif command_exists "free"; then
     cached_eval free | awk -v format="$ram_percentage_format" '$1 ~ /Mem/ {printf(format, 100*$3/$2)}'
   elif command_exists "vm_stat"; then
     # page size of 4096 bytes

--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -15,7 +15,7 @@ sum_macos_vm_stats() {
 print_ram_percentage() {
   ram_percentage_format=$(get_tmux_option "@ram_percentage_format" "$ram_percentage_format")
 
-  if $(get_tmux_option @ram_wsl) == "true" && test -n "${WSL_DISTRO_NAME}"; then
+  if [[ $(get_tmux_option @ram_wsl_host) == "true" && -n "${WSL_DISTRO_NAME}" ]] ; then
 
     # TotalPhysicalMemory is in bytes, but FreePhysicalMemory is in KiB
     total=$(wmic.exe ComputerSystem get TotalPhysicalMemory | awk '/^[0-9]/{print $1/1024}')


### PR DESCRIPTION
This PR adds support to gather CPU & RAM % usage of the Windows host system when using Windows subsystem for Linux.

As the guest CPU / RAM can be limited by WSL config the current methods are not indicative of the whole system.

This also adds two new options: `@cpu_wsl_host` and `@ram_wsl_host` to control if this data should come from the guest or the host - when set the data comes from querying wmic.exe