### PR TITLE
freebsd compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ This is done by introducing 12 new format strings that can be added to
 - `#{cpu_bg_color}` - will change the background color based on the CPU percentage
 - `#{cpu_fg_color}` - will change the foreground color based on the CPU percentage
 - `#{ram_icon}` - will display a RAM status icon
-- `#{ram_percentage}` - will show RAM percentage (averaged across cores)
+- `#{ram_percentage}` - will show RAM percentage (averaged across cores)\
+  (freebsd user will need to install `freecolor`: `$ pkg install freecolor`)
 - `#{ram_bg_color}` - will change the background color based on the RAM percentage
 - `#{ram_fg_color}` - will change the foreground color based on the RAM percentage
 - `#{cpu_temp_icon}` - will display a CPU temperature status icon

--- a/scripts/cpu_percentage.sh
+++ b/scripts/cpu_percentage.sh
@@ -17,7 +17,7 @@ print_cpu_percentage() {
     elif is_osx; then
       cached_eval iostat -c 2 disk0 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$6} END {printf(format, usage)}' | sed 's/,/./'
     elif is_freebsd || is_openbsd; then
-      cached_eval iostat -c 2 | sed '/^\s*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
+      cached_eval iostat -c 2 | sed '/^[[:space:]]*$/d' | tail -n 1 | awk -v format="$cpu_percentage_format" '{usage=100-$NF} END {printf(format, usage)}' | sed 's/,/./'
     else
       echo "Unknown iostat version please create an issue"
     fi

--- a/scripts/ram_percentage.sh
+++ b/scripts/ram_percentage.sh
@@ -17,6 +17,8 @@ print_ram_percentage() {
 
   if command_exists "free"; then
     cached_eval free | awk -v format="$ram_percentage_format" '$1 ~ /Mem/ {printf(format, 100*$3/$2)}'
+  elif command_exists "freecolor"; then # freebsd: install freecolor first: $ pkg install freecolor
+    cached_eval freecolor -m -o | awk -v format="$ram_percentage_format" '$1 ~ /Mem/ {printf(format, 100*$3/$2)}'
   elif command_exists "vm_stat"; then
     # page size of 4096 bytes
     stats="$(cached_eval vm_stat)"


### PR DESCRIPTION
Hi,

I fixed two issues to make tmux-cpu more compatible to freebsd.

To get memory usage the easiest way is to install `freecolor`. Unfortunately it counts cached memory as 'used' not as 'free'.

Second bug: FreeBSD `sed` can't handle `\s`, i replaced it with `[[:space:]]`.