### PR TITLE
Replace date with perl to fix get_time() on macOS

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -104,7 +104,7 @@ get_tmp_dir() {
 }
 
 get_time() {
-  date +%s.%N
+  perl -MTime::HiRes=time -e 'printf "%.9f\n", time'
 }
 
 get_cache_val() {


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
The BSD date on macOS doesn't support %N. It just prints a literal N (e.g. '1738285044.N'), which breaks the awk command in get_cache_val(), stopping cached values from being updated.

Instead, I found this perl command at [1]. Tested on macOS, Arch Linux, and OpenWRT (which has a minimal perl distribution. By the way, BusyBox date doesn't support %N either but it just prints e.g. '1738285044.' without an 'N'. So while the awk command works, [2] didn't really improve the time precision here).

[1] https://apple.stackexchange.com/a/359718/254536
[2] https://github.com/tmux-plugins/tmux-cpu/pull/56/files#diff-e015cc3ac522b202bb23852488a7ac2c019e2c82568ecb387b97b60ebbecdf4bR72-R74
<!-- === GH HISTORY FENCE === -->
